### PR TITLE
ci: enforce rustfmt formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,13 @@ jobs:
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           toolchain: 1.92.0
-          components: clippy
+          components: clippy,rustfmt
 
       - name: Cache Rust dependencies
         uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
       - name: Lint with Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/crates/edi-adapter-csv/src/reader.rs
+++ b/crates/edi-adapter-csv/src/reader.rs
@@ -327,10 +327,7 @@ impl<R: Read> CsvRecordIterator<R> {
 
         let (headers, pending_error) = if has_header {
             match csv_reader.headers() {
-                Ok(headers) => (
-                    headers.iter().map(|s| s.to_string()).collect(),
-                    None,
-                ),
+                Ok(headers) => (headers.iter().map(|s| s.to_string()).collect(), None),
                 Err(error) => (Vec::new(), Some(CsvError::read_at(1, error.to_string()))),
             }
         } else {

--- a/crates/edi-cli/tests/parse_command_test.rs
+++ b/crates/edi-cli/tests/parse_command_test.rs
@@ -84,7 +84,9 @@ fn parse_command_outputs_json_to_stdout() {
         .as_array()
         .expect("parse output should be a JSON array");
     assert!(
-        documents.iter().any(|document| document.get("root").is_some()),
+        documents
+            .iter()
+            .any(|document| document.get("root").is_some()),
         "at least one parsed document should include a 'root' field"
     );
 


### PR DESCRIPTION
## Summary

- Fix current rustfmt drift in `main`.
- Add a GitHub Actions formatting gate with `cargo fmt --all -- --check` before clippy/tests.

Closes #117
Closes #118

## Test Plan

- [x] RED: `cargo fmt --all -- --check` failed before formatting, showing drift in:
  - `crates/edi-adapter-csv/src/reader.rs`
  - `crates/edi-cli/tests/parse_command_test.rs`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-targets --all-features`

## Scope

CI/hygiene only. No parser, mapping, validation, adapter, or CLI behavior changes intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with an additional code formatting verification step to validate code standards alongside existing linting and testing processes.
  * Code reformatting and test assertion updates to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->