### PR TITLE
feat(cli): add project init and config profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,39 @@ Generate EDI from CSV/JSON input using a mapping:
 edi generate <input.{csv|json}> <output.edi> -m <mapping.yaml> [--input-format csv|json]
 ```
 
-Config file flag (currently ignored in MVP):
+Project config workflow:
 
 ```bash
-edi --config <path> <subcommand>
+edi init --profile orders
+edi config check --profile orders
+edi --profile orders validate
+edi --profile orders transform
 ```
+
+`edi init` creates `rsedi.yaml` plus starter directories (`schemas/`, `mappings/`,
+`input/`, `output/`, `quarantine/`). Profiles can store common input, output,
+schema, mapping, quarantine, progress, and color defaults so repeated partner or
+environment workflows do not need long flag lists. Explicit CLI arguments still
+override profile values.
+
+Example `rsedi.yaml`:
+
+```yaml
+progress: true
+progress_threshold_bytes: 1048576
+color: auto
+profiles:
+  orders:
+    input: input/orders.edi
+    output: output/orders.json
+    schema: schemas/eancom_orders_d96a.yaml
+    mapping: mappings/orders_to_json.yaml
+    quarantine: quarantine
+    output_format: json
+```
+
+Legacy config paths such as `edi-cli.yaml` are still discovered, but new projects
+should prefer `rsedi.yaml`.
 
 ### Exit Codes
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Rust workspace for parsing, validating, and transforming UN/EDIFACT EDI (EANCOM-
 ## Status
 
 - MVP focus: ORDERS (EANCOM D96A) parse, validate, map to IR/JSON.
-- CLI supports `transform`, `validate`, and `generate` subcommands. Config-file support is still a placeholder.
+- CLI supports `transform`, `validate`, and `generate` subcommands with functional `rsedi.yaml` config profiles via `edi init` and `edi config check`.
 - CSV adapter and pipeline logic exist as building blocks; DB adapter types are present but not wired to a driver.
 - Streaming at message boundaries is a design goal; current CLI reads full input files into memory.
 
@@ -156,8 +156,6 @@ cargo test --all-targets --all-features
 
 ## Known MVP Limitations
 
-- `edi --config` is accepted but ignored.
-- `edi generate` currently supports CSV and JSON input sources only.
 - `edi transform` ignores the optional schema flag for now.
 - CLI runs on full in-memory files rather than streaming chunks.
 

--- a/crates/edi-cli/src/main.rs
+++ b/crates/edi-cli/src/main.rs
@@ -6,6 +6,7 @@
 //! EDI transformations and managing configurations.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::env;
 use std::fs::File;
 use std::io::{IsTerminal, Write};
@@ -54,6 +55,10 @@ struct CliConfig {
     progress: bool,
     progress_threshold_bytes: u64,
     color: ColorMode,
+    profiles: HashMap<String, ProfileConfig>,
+
+    #[serde(skip)]
+    source_path: Option<PathBuf>,
 }
 
 impl Default for CliConfig {
@@ -62,8 +67,24 @@ impl Default for CliConfig {
             progress: true,
             progress_threshold_bytes: 1024 * 1024,
             color: ColorMode::Auto,
+            profiles: HashMap::new(),
+            source_path: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct ProfileConfig {
+    input: Option<PathBuf>,
+    output: Option<PathBuf>,
+    schema: Option<PathBuf>,
+    mapping: Option<PathBuf>,
+    quarantine: Option<PathBuf>,
+    output_format: Option<String>,
+    color: Option<ColorMode>,
+    progress: Option<bool>,
+    progress_threshold_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -166,6 +187,10 @@ struct Cli {
     #[arg(short, long)]
     config: Option<String>,
 
+    /// Named project profile to apply from the config file
+    #[arg(long, global = true)]
+    profile: Option<String>,
+
     /// Subcommand to execute
     #[command(subcommand)]
     command: Commands,
@@ -173,17 +198,34 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Create a starter rsedi.yaml and workspace directories
+    Init {
+        /// Profile name to create in the starter config
+        #[arg(long, default_value = "default")]
+        profile: String,
+
+        /// Overwrite an existing rsedi.yaml
+        #[arg(long, default_value_t = false)]
+        force: bool,
+    },
+
+    /// Manage CLI configuration
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommands,
+    },
+
     /// Transform an EDI file
     Transform {
-        /// Input file path
-        input: String,
+        /// Input file path (uses profile input when omitted)
+        input: Option<String>,
 
-        /// Output file path (writes to stdout when omitted)
+        /// Output file path (writes to stdout when omitted unless profile output is set)
         output: Option<String>,
 
         /// Mapping file path
         #[arg(short, long)]
-        mapping: String,
+        mapping: Option<String>,
 
         /// Schema file path
         #[arg(short, long)]
@@ -192,12 +234,12 @@ enum Commands {
 
     /// Validate an EDI file against a schema
     Validate {
-        /// Input file path
-        input: String,
+        /// Input file path (uses profile input when omitted)
+        input: Option<String>,
 
         /// Schema file path
         #[arg(short, long)]
-        schema: String,
+        schema: Option<String>,
     },
 
     /// Parse an EDI file and output JSON IR
@@ -215,19 +257,29 @@ enum Commands {
 
     /// Generate EDI output from CSV/JSON input using a mapping
     Generate {
-        /// Input file path (CSV or JSON)
-        input: String,
+        /// Input file path (CSV or JSON; uses profile input when omitted)
+        input: Option<String>,
 
-        /// Output file path (writes to stdout when omitted)
+        /// Output file path (writes to stdout when omitted unless profile output is set)
         output: Option<String>,
 
         /// Mapping file path
         #[arg(short, long)]
-        mapping: String,
+        mapping: Option<String>,
 
         /// Source input format (inferred from file extension or mapping source_type when omitted)
         #[arg(long, value_enum)]
         input_format: Option<GenerateInputFormat>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommands {
+    /// Validate project configuration and referenced files
+    Check {
+        /// Profile to check (defaults to --profile or all profiles)
+        #[arg(long)]
+        profile: Option<String>,
     },
 }
 
@@ -246,50 +298,145 @@ fn main() -> ExitCode {
 fn run() -> anyhow::Result<CliExitCode> {
     let cli = Cli::parse();
     let config = load_cli_config(cli.config.as_deref())?;
-    let runtime = RuntimeOptions {
-        progress: config.progress,
-        progress_threshold_bytes: config.progress_threshold_bytes,
-        color: config.color,
-    };
+    let base_runtime = runtime_options(&config, None);
 
     if let Some(config_path) = cli.config.as_deref() {
         tracing::info!(config = %config_path, "Loaded explicit CLI config");
+    } else if let Some(config_path) = &config.source_path {
+        tracing::info!(config = %config_path.display(), "Loaded discovered CLI config");
     }
 
-    let command_result = match cli.command {
-        Commands::Transform {
-            input,
-            output,
-            mapping,
-            schema,
-        } => transform(
-            &input,
-            output.as_deref(),
-            &mapping,
-            schema.as_deref(),
-            runtime,
-        ),
-        Commands::Validate { input, schema } => validate(&input, &schema, runtime),
-        Commands::Parse {
-            input,
-            output,
-            pretty,
-        } => parse(&input, output.as_deref(), pretty, runtime),
-        Commands::Generate {
-            input,
-            output,
-            mapping,
-            input_format,
-        } => generate(&input, output.as_deref(), &mapping, input_format, runtime),
-    };
+    let command_result = (|| -> anyhow::Result<CliExitCode> {
+        match cli.command {
+            Commands::Init { profile, force } => {
+                init_project(cli.profile.as_deref().unwrap_or(&profile), force)
+            }
+            Commands::Config { command } => match command {
+                ConfigCommands::Check { profile } => {
+                    config_check(&config, profile.as_deref().or(cli.profile.as_deref()))
+                }
+            },
+            Commands::Transform {
+                input,
+                output,
+                mapping,
+                schema,
+            } => {
+                let profile = resolve_selected_profile(&config, cli.profile.as_deref())?;
+                let runtime = runtime_options(&config, profile);
+                let input =
+                    resolve_profile_value(input, profile.and_then(|p| p.input.as_ref()), "input")?;
+                let output =
+                    resolve_optional_profile_value(output, profile.and_then(|p| p.output.as_ref()));
+                let mapping = resolve_profile_value(
+                    mapping,
+                    profile.and_then(|p| p.mapping.as_ref()),
+                    "mapping",
+                )?;
+                let schema =
+                    resolve_optional_profile_value(schema, profile.and_then(|p| p.schema.as_ref()));
+                transform(
+                    &input,
+                    output.as_deref(),
+                    &mapping,
+                    schema.as_deref(),
+                    runtime,
+                )
+            }
+            Commands::Validate { input, schema } => {
+                let profile = resolve_selected_profile(&config, cli.profile.as_deref())?;
+                let runtime = runtime_options(&config, profile);
+                let input =
+                    resolve_profile_value(input, profile.and_then(|p| p.input.as_ref()), "input")?;
+                let schema = resolve_profile_value(
+                    schema,
+                    profile.and_then(|p| p.schema.as_ref()),
+                    "schema",
+                )?;
+                validate(&input, &schema, runtime)
+            }
+            Commands::Parse {
+                input,
+                output,
+                pretty,
+            } => parse(&input, output.as_deref(), pretty, base_runtime),
+            Commands::Generate {
+                input,
+                output,
+                mapping,
+                input_format,
+            } => {
+                let profile = resolve_selected_profile(&config, cli.profile.as_deref())?;
+                let runtime = runtime_options(&config, profile);
+                let input =
+                    resolve_profile_value(input, profile.and_then(|p| p.input.as_ref()), "input")?;
+                let output =
+                    resolve_optional_profile_value(output, profile.and_then(|p| p.output.as_ref()));
+                let mapping = resolve_profile_value(
+                    mapping,
+                    profile.and_then(|p| p.mapping.as_ref()),
+                    "mapping",
+                )?;
+                generate(&input, output.as_deref(), &mapping, input_format, runtime)
+            }
+        }
+    })();
 
     match command_result {
         Ok(code) => Ok(code),
         Err(error) => {
-            print_error(runtime.color, &format!("{error:#}"));
+            print_error(base_runtime.color, &format!("{error:#}"));
             Ok(CliExitCode::Errors)
         }
     }
+}
+
+fn runtime_options(config: &CliConfig, profile: Option<&ProfileConfig>) -> RuntimeOptions {
+    RuntimeOptions {
+        progress: profile.and_then(|p| p.progress).unwrap_or(config.progress),
+        progress_threshold_bytes: profile
+            .and_then(|p| p.progress_threshold_bytes)
+            .unwrap_or(config.progress_threshold_bytes),
+        color: profile.and_then(|p| p.color).unwrap_or(config.color),
+    }
+}
+
+fn resolve_selected_profile<'a>(
+    config: &'a CliConfig,
+    profile_name: Option<&str>,
+) -> anyhow::Result<Option<&'a ProfileConfig>> {
+    match profile_name {
+        Some(name) => config
+            .profiles
+            .get(name)
+            .map(Some)
+            .ok_or_else(|| anyhow!("Profile '{}' was not found in the CLI config", name)),
+        None => Ok(None),
+    }
+}
+
+fn resolve_profile_value(
+    explicit: Option<String>,
+    profile_value: Option<&PathBuf>,
+    field: &str,
+) -> anyhow::Result<String> {
+    explicit
+        .or_else(|| profile_value.map(|path| path.to_string_lossy().into_owned()))
+        .ok_or_else(|| {
+            let flag_hint = match field {
+                "mapping" => "--mapping",
+                "schema" => "--schema",
+                _ => field,
+            };
+            anyhow!("Missing {field}; pass {flag_hint} or select a profile that defines {field}")
+        })
+}
+
+fn resolve_optional_profile_value(
+    explicit: Option<String>,
+    profile_value: Option<&PathBuf>,
+) -> Option<String> {
+    explicit.or_else(|| profile_value.map(|path| path.to_string_lossy().into_owned()))
 }
 
 fn load_cli_config(explicit_path: Option<&str>) -> anyhow::Result<CliConfig> {
@@ -310,14 +457,39 @@ fn load_cli_config(explicit_path: Option<&str>) -> anyhow::Result<CliConfig> {
 fn read_cli_config_file(path: &Path) -> anyhow::Result<CliConfig> {
     let bytes = std::fs::read(path)
         .with_context(|| format!("Failed to read CLI config '{}'", path.display()))?;
-    serde_yaml::from_slice(&bytes)
-        .with_context(|| format!("Failed to parse CLI config '{}'", path.display()))
+    let mut config: CliConfig = serde_yaml::from_slice(&bytes)
+        .with_context(|| format!("Failed to parse CLI config '{}'", path.display()))?;
+    config.source_path = Some(path.to_path_buf());
+    if let Some(base_dir) = path.parent() {
+        for profile in config.profiles.values_mut() {
+            resolve_profile_paths(base_dir, profile);
+        }
+    }
+    Ok(config)
+}
+
+fn resolve_profile_paths(base_dir: &Path, profile: &mut ProfileConfig) {
+    absolutize_profile_path(base_dir, &mut profile.input);
+    absolutize_profile_path(base_dir, &mut profile.output);
+    absolutize_profile_path(base_dir, &mut profile.schema);
+    absolutize_profile_path(base_dir, &mut profile.mapping);
+    absolutize_profile_path(base_dir, &mut profile.quarantine);
+}
+
+fn absolutize_profile_path(base_dir: &Path, value: &mut Option<PathBuf>) {
+    if let Some(path) = value {
+        if path.is_relative() {
+            *path = base_dir.join(&path);
+        }
+    }
 }
 
 fn default_config_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
     if let Ok(current_dir) = env::current_dir() {
+        paths.push(current_dir.join("rsedi.yaml"));
+        paths.push(current_dir.join("edi.yaml"));
         paths.push(current_dir.join("edi-cli.yaml"));
         paths.push(current_dir.join(".edi-cli.yaml"));
     }
@@ -331,6 +503,111 @@ fn default_config_paths() -> Vec<PathBuf> {
     }
 
     paths
+}
+
+fn init_project(profile: &str, force: bool) -> anyhow::Result<CliExitCode> {
+    let config_path = Path::new("rsedi.yaml");
+    if config_path.exists() && !force {
+        bail!(
+            "Config '{}' already exists; pass --force to overwrite it",
+            config_path.display()
+        );
+    }
+
+    for dir in ["schemas", "mappings", "input", "output", "quarantine"] {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create directory '{dir}'"))?;
+    }
+
+    let config = format!(
+        r#"# rsedi project configuration
+# Use --profile {profile} to apply these defaults to validate/transform/generate.
+progress: true
+progress_threshold_bytes: 1048576
+color: auto
+profiles:
+  {profile}:
+    input: input/example.edi
+    output: output/result.json
+    schema: schemas/example.yaml
+    mapping: mappings/example.yaml
+    quarantine: quarantine
+    output_format: json
+"#
+    );
+    std::fs::write(config_path, config)
+        .with_context(|| format!("Failed to write '{}'", config_path.display()))?;
+
+    println!(
+        "Created {} with profile '{}'.",
+        config_path.display(),
+        profile
+    );
+    println!("Created starter directories: schemas, mappings, input, output, quarantine.");
+    Ok(CliExitCode::Success)
+}
+
+fn config_check(config: &CliConfig, profile_name: Option<&str>) -> anyhow::Result<CliExitCode> {
+    if config.source_path.is_none() {
+        bail!("No config file found. Run 'edi init' or pass --config <path>.");
+    }
+
+    let profiles: Vec<(&str, &ProfileConfig)> = if let Some(name) = profile_name {
+        vec![
+            config
+                .profiles
+                .get_key_value(name)
+                .map(|(key, profile)| (key.as_str(), profile))
+                .ok_or_else(|| anyhow!("Profile '{}' was not found in the CLI config", name))?,
+        ]
+    } else {
+        config
+            .profiles
+            .iter()
+            .map(|(name, profile)| (name.as_str(), profile))
+            .collect()
+    };
+
+    if profiles.is_empty() {
+        bail!("Config contains no profiles.");
+    }
+
+    let mut missing = Vec::new();
+    for (name, profile) in &profiles {
+        check_profile_file(name, "schema", profile.schema.as_ref(), &mut missing);
+        check_profile_file(name, "mapping", profile.mapping.as_ref(), &mut missing);
+    }
+
+    if !missing.is_empty() {
+        for line in &missing {
+            eprintln!("Missing: {line}");
+        }
+        return Ok(CliExitCode::Errors);
+    }
+
+    let checked = profiles
+        .iter()
+        .map(|(name, _)| *name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("Config OK: checked profile(s): {checked}");
+    Ok(CliExitCode::Success)
+}
+
+fn check_profile_file(
+    profile_name: &str,
+    field: &str,
+    path: Option<&PathBuf>,
+    missing: &mut Vec<String>,
+) {
+    if let Some(path) = path {
+        if !path.exists() {
+            missing.push(format!(
+                "profile '{profile_name}' {field} file '{}' does not exist",
+                path.display()
+            ));
+        }
+    }
 }
 
 fn use_color(mode: ColorMode) -> bool {

--- a/crates/edi-cli/src/main.rs
+++ b/crates/edi-cli/src/main.rs
@@ -506,6 +506,8 @@ fn default_config_paths() -> Vec<PathBuf> {
 }
 
 fn init_project(profile: &str, force: bool) -> anyhow::Result<CliExitCode> {
+    ensure_valid_profile_name(profile)?;
+
     let config_path = Path::new("rsedi.yaml");
     if config_path.exists() && !force {
         bail!(
@@ -547,6 +549,21 @@ profiles:
     Ok(CliExitCode::Success)
 }
 
+fn ensure_valid_profile_name(profile: &str) -> anyhow::Result<()> {
+    if profile.is_empty()
+        || !profile
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    {
+        bail!(
+            "Invalid profile name '{}'; use only ASCII letters, digits, '.', '_' or '-'",
+            profile
+        );
+    }
+
+    Ok(())
+}
+
 fn config_check(config: &CliConfig, profile_name: Option<&str>) -> anyhow::Result<CliExitCode> {
     if config.source_path.is_none() {
         bail!("No config file found. Run 'edi init' or pass --config <path>.");
@@ -574,8 +591,16 @@ fn config_check(config: &CliConfig, profile_name: Option<&str>) -> anyhow::Resul
 
     let mut missing = Vec::new();
     for (name, profile) in &profiles {
-        check_profile_file(name, "schema", profile.schema.as_ref(), &mut missing);
-        check_profile_file(name, "mapping", profile.mapping.as_ref(), &mut missing);
+        check_profile_path(name, "input", profile.input.as_ref(), &mut missing);
+        check_profile_path(name, "output", profile.output.as_ref(), &mut missing);
+        check_profile_path(name, "schema", profile.schema.as_ref(), &mut missing);
+        check_profile_path(name, "mapping", profile.mapping.as_ref(), &mut missing);
+        check_profile_path(
+            name,
+            "quarantine",
+            profile.quarantine.as_ref(),
+            &mut missing,
+        );
     }
 
     if !missing.is_empty() {
@@ -594,7 +619,7 @@ fn config_check(config: &CliConfig, profile_name: Option<&str>) -> anyhow::Resul
     Ok(CliExitCode::Success)
 }
 
-fn check_profile_file(
+fn check_profile_path(
     profile_name: &str,
     field: &str,
     path: Option<&PathBuf>,
@@ -603,7 +628,7 @@ fn check_profile_file(
     if let Some(path) = path {
         if !path.exists() {
             missing.push(format!(
-                "profile '{profile_name}' {field} file '{}' does not exist",
+                "profile '{profile_name}' {field} path '{}' does not exist",
                 path.display()
             ));
         }

--- a/crates/edi-cli/tests/config_profiles_test.rs
+++ b/crates/edi-cli/tests/config_profiles_test.rs
@@ -1,0 +1,267 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn cargo_bin() -> PathBuf {
+    if let Ok(path) = env::var("CARGO_BIN_EXE_edi") {
+        return PathBuf::from(path);
+    }
+
+    let target_dir = env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| repo_root().join("target"));
+    let executable_name = format!("edi{}", std::env::consts::EXE_SUFFIX);
+    let fallback = target_dir.join("debug").join(executable_name);
+
+    if fallback.exists() {
+        return fallback;
+    }
+
+    panic!(
+        "CARGO_BIN_EXE_edi is not set and fallback binary was not found at {}",
+        fallback.display()
+    );
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn testdata_path(path: &str) -> PathBuf {
+    repo_root().join(path)
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after UNIX_EPOCH")
+            .as_nanos();
+        let path = env::temp_dir().join(format!("edi-cli-{name}-{}-{nanos}", std::process::id()));
+        fs::create_dir_all(&path).expect("temporary directory should be created");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn assert_exit_code(output: &Output, expected: i32) {
+    let actual = output.status.code().unwrap_or(-1);
+    assert_eq!(
+        actual,
+        expected,
+        "unexpected exit code; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn init_creates_starter_config_and_directories() {
+    let temp = TempDir::new("init-profile");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["init", "--profile", "orders"])
+        .output()
+        .expect("edi init should execute");
+
+    assert_exit_code(&output, 0);
+    assert!(temp.path().join("rsedi.yaml").exists());
+    assert!(temp.path().join("schemas").is_dir());
+    assert!(temp.path().join("mappings").is_dir());
+    assert!(temp.path().join("input").is_dir());
+    assert!(temp.path().join("output").is_dir());
+    assert!(temp.path().join("quarantine").is_dir());
+
+    let config = fs::read_to_string(temp.path().join("rsedi.yaml"))
+        .expect("generated config should be readable");
+    assert!(config.contains("profiles:"));
+    assert!(config.contains("orders:"));
+    assert!(config.contains("schema:"));
+    assert!(config.contains("mapping:"));
+}
+
+#[test]
+fn config_check_validates_profile_referenced_files() {
+    let temp = TempDir::new("config-check-valid");
+    fs::create_dir_all(temp.path().join("schemas")).expect("schema dir");
+    fs::create_dir_all(temp.path().join("mappings")).expect("mapping dir");
+    fs::write(
+        temp.path().join("schemas/orders.yaml"),
+        "name: ORDERS\nversion: D96A\nsegments: []\n",
+    )
+    .expect("schema file");
+    fs::write(
+        temp.path().join("mappings/orders.yaml"),
+        "source_type: EDI\ntarget_type: JSON\nrules: []\n",
+    )
+    .expect("mapping file");
+    fs::write(
+        temp.path().join("rsedi.yaml"),
+        r#"profiles:
+  orders:
+    input: input/orders.edi
+    output: output/orders.json
+    schema: schemas/orders.yaml
+    mapping: mappings/orders.yaml
+    quarantine: quarantine
+    output_format: json
+"#,
+    )
+    .expect("config file");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["config", "check", "--profile", "orders"])
+        .output()
+        .expect("edi config check should execute");
+
+    assert_exit_code(&output, 0);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Config OK"));
+    assert!(stdout.contains("orders"));
+}
+
+#[test]
+fn config_check_reports_unknown_keys_and_missing_files() {
+    let temp = TempDir::new("config-check-invalid");
+    fs::write(
+        temp.path().join("rsedi.yaml"),
+        r#"profiles:
+  orders:
+    schema: schemas/missing.yaml
+    mapping: mappings/missing.yaml
+    typo_path: nope
+"#,
+    )
+    .expect("config file");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["config", "check", "--profile", "orders"])
+        .output()
+        .expect("edi config check should execute");
+
+    assert_exit_code(&output, 3);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("unknown field"));
+    assert!(stderr.contains("typo_path"));
+}
+
+#[test]
+fn config_check_reports_missing_referenced_files() {
+    let temp = TempDir::new("config-check-missing-files");
+    fs::write(
+        temp.path().join("rsedi.yaml"),
+        r#"profiles:
+  orders:
+    schema: schemas/missing.yaml
+    mapping: mappings/missing.yaml
+"#,
+    )
+    .expect("config file");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["config", "check", "--profile", "orders"])
+        .output()
+        .expect("edi config check should execute");
+
+    assert_exit_code(&output, 2);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Missing:"));
+    assert!(stderr.contains("schemas/missing.yaml"));
+    assert!(stderr.contains("mappings/missing.yaml"));
+}
+
+#[test]
+fn validate_uses_profile_paths_from_default_config() {
+    let temp = TempDir::new("validate-profile");
+    fs::create_dir_all(temp.path().join("schemas")).expect("schema dir");
+    fs::create_dir_all(temp.path().join("input")).expect("input dir");
+    fs::copy(
+        testdata_path("testdata/schemas/eancom_orders_d96a.yaml"),
+        temp.path().join("schemas/orders.yaml"),
+    )
+    .expect("schema copy");
+    fs::copy(
+        testdata_path("testdata/edi/valid_orders_d96a_minimal.edi"),
+        temp.path().join("input/orders.edi"),
+    )
+    .expect("input copy");
+    fs::write(
+        temp.path().join("rsedi.yaml"),
+        r#"profiles:
+  orders:
+    input: input/orders.edi
+    schema: schemas/orders.yaml
+"#,
+    )
+    .expect("config file");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["--profile", "orders", "validate"])
+        .output()
+        .expect("edi validate should execute");
+
+    assert_exit_code(&output, 0);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Validation passed with no warnings."));
+}
+
+#[test]
+fn transform_uses_profile_paths_for_input_mapping_and_output() {
+    let temp = TempDir::new("transform-profile");
+    fs::create_dir_all(temp.path().join("input")).expect("input dir");
+    fs::create_dir_all(temp.path().join("mappings")).expect("mapping dir");
+    fs::create_dir_all(temp.path().join("output")).expect("output dir");
+    fs::copy(
+        testdata_path("testdata/edi/valid_orders_d96a_minimal.edi"),
+        temp.path().join("input/orders.edi"),
+    )
+    .expect("input copy");
+    fs::copy(
+        testdata_path("testdata/mappings/orders_to_json.yaml"),
+        temp.path().join("mappings/orders_to_json.yaml"),
+    )
+    .expect("mapping copy");
+    fs::write(
+        temp.path().join("rsedi.yaml"),
+        r#"profiles:
+  orders:
+    input: input/orders.edi
+    output: output/orders.json
+    mapping: mappings/orders_to_json.yaml
+"#,
+    )
+    .expect("config file");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["--profile", "orders", "transform"])
+        .output()
+        .expect("edi transform should execute");
+
+    assert_exit_code(&output, 0);
+    let json = fs::read_to_string(temp.path().join("output/orders.json"))
+        .expect("profile output should be written");
+    assert!(json.contains("ORDER123"));
+}

--- a/crates/edi-cli/tests/config_profiles_test.rs
+++ b/crates/edi-cli/tests/config_profiles_test.rs
@@ -61,6 +61,10 @@ impl Drop for TempDir {
     }
 }
 
+const EXIT_SUCCESS: i32 = 0;
+const EXIT_ERRORS: i32 = 2;
+const EXIT_CONFIG_ERROR: i32 = 3;
+
 fn assert_exit_code(output: &Output, expected: i32) {
     let actual = output.status.code().unwrap_or(-1);
     assert_eq!(
@@ -82,7 +86,7 @@ fn init_creates_starter_config_and_directories() {
         .output()
         .expect("edi init should execute");
 
-    assert_exit_code(&output, 0);
+    assert_exit_code(&output, EXIT_SUCCESS);
     assert!(temp.path().join("rsedi.yaml").exists());
     assert!(temp.path().join("schemas").is_dir());
     assert!(temp.path().join("mappings").is_dir());
@@ -99,10 +103,29 @@ fn init_creates_starter_config_and_directories() {
 }
 
 #[test]
+fn init_rejects_profile_names_that_would_break_yaml() {
+    let temp = TempDir::new("init-invalid-profile");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(temp.path())
+        .args(["init", "--profile", "bad: name"])
+        .output()
+        .expect("edi init should execute");
+
+    assert_exit_code(&output, EXIT_ERRORS);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Invalid profile name"));
+    assert!(!temp.path().join("rsedi.yaml").exists());
+}
+
+#[test]
 fn config_check_validates_profile_referenced_files() {
     let temp = TempDir::new("config-check-valid");
     fs::create_dir_all(temp.path().join("schemas")).expect("schema dir");
     fs::create_dir_all(temp.path().join("mappings")).expect("mapping dir");
+    fs::create_dir_all(temp.path().join("input")).expect("input dir");
+    fs::create_dir_all(temp.path().join("output")).expect("output dir");
+    fs::create_dir_all(temp.path().join("quarantine")).expect("quarantine dir");
     fs::write(
         temp.path().join("schemas/orders.yaml"),
         "name: ORDERS\nversion: D96A\nsegments: []\n",
@@ -113,6 +136,12 @@ fn config_check_validates_profile_referenced_files() {
         "source_type: EDI\ntarget_type: JSON\nrules: []\n",
     )
     .expect("mapping file");
+    fs::write(
+        temp.path().join("input/orders.edi"),
+        "UNH+1+ORDERS:D:96A:UN'",
+    )
+    .expect("input file");
+    fs::write(temp.path().join("output/orders.json"), "{}").expect("output file");
     fs::write(
         temp.path().join("rsedi.yaml"),
         r#"profiles:
@@ -133,7 +162,7 @@ fn config_check_validates_profile_referenced_files() {
         .output()
         .expect("edi config check should execute");
 
-    assert_exit_code(&output, 0);
+    assert_exit_code(&output, EXIT_SUCCESS);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Config OK"));
     assert!(stdout.contains("orders"));
@@ -159,7 +188,7 @@ fn config_check_reports_unknown_keys_and_missing_files() {
         .output()
         .expect("edi config check should execute");
 
-    assert_exit_code(&output, 3);
+    assert_exit_code(&output, EXIT_CONFIG_ERROR);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("unknown field"));
     assert!(stderr.contains("typo_path"));
@@ -172,8 +201,11 @@ fn config_check_reports_missing_referenced_files() {
         temp.path().join("rsedi.yaml"),
         r#"profiles:
   orders:
+    input: input/missing.edi
+    output: output/missing.json
     schema: schemas/missing.yaml
     mapping: mappings/missing.yaml
+    quarantine: quarantine
 "#,
     )
     .expect("config file");
@@ -184,11 +216,14 @@ fn config_check_reports_missing_referenced_files() {
         .output()
         .expect("edi config check should execute");
 
-    assert_exit_code(&output, 2);
+    assert_exit_code(&output, EXIT_ERRORS);
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("Missing:"));
     assert!(stderr.contains("schemas/missing.yaml"));
     assert!(stderr.contains("mappings/missing.yaml"));
+    assert!(stderr.contains("input/missing.edi"));
+    assert!(stderr.contains("output/missing.json"));
+    assert!(stderr.contains("quarantine"));
 }
 
 #[test]
@@ -222,7 +257,7 @@ fn validate_uses_profile_paths_from_default_config() {
         .output()
         .expect("edi validate should execute");
 
-    assert_exit_code(&output, 0);
+    assert_exit_code(&output, EXIT_SUCCESS);
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Validation passed with no warnings."));
 }
@@ -260,7 +295,7 @@ fn transform_uses_profile_paths_for_input_mapping_and_output() {
         .output()
         .expect("edi transform should execute");
 
-    assert_exit_code(&output, 0);
+    assert_exit_code(&output, EXIT_SUCCESS);
     let json = fs::read_to_string(temp.path().join("output/orders.json"))
         .expect("profile output should be written");
     assert!(json.contains("ORDER123"));

--- a/crates/edi-cli/tests/generate_command_test.rs
+++ b/crates/edi-cli/tests/generate_command_test.rs
@@ -266,7 +266,7 @@ fn generate_help_includes_mapping_and_input_format_flags() {
     assert!(output.status.success(), "generate --help should succeed");
 
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
-    assert!(stdout.contains("<INPUT>"));
+    assert!(stdout.contains("[INPUT]"));
     assert!(stdout.contains("[OUTPUT]"));
     assert!(stdout.contains("--mapping <MAPPING>"));
     assert!(stdout.contains("--input-format <INPUT_FORMAT>"));


### PR DESCRIPTION
## Summary
- add `edi init` to create `rsedi.yaml` and starter project directories
- add named config profiles, `--profile`, and profile-backed defaults for validate/transform/generate
- add `edi config check` to validate config files and referenced profile paths
- document the new project config workflow

Closes #120

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for named project profiles in configuration files
  * New `init` command to initialize projects with starter configuration
  * New `config check` command to validate configuration files
  * Global `--profile` flag to select configuration profiles
  * Commands now resolve settings from profiles when not explicitly provided

* **Documentation**
  * Updated README with configuration workflow and `rsedi.yaml` format examples

* **Tests**
  * Added integration tests for profile functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->