### PR TITLE
feat(cli): add schema pack registry and auto-detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -482,6 +482,7 @@ gh api -X POST repos/<owner>/<repo>/issues/<parent>/sub_issues -f sub_issue_id=<
 --- 
 
 ## Learnings
+- 2026-06-12 (`#124`): CLI auto-schema works best when schema pack IDs are derived deterministically from the first message UNH composite (`message_type`, `release+version`) and validation reports display the selected pack ID rather than an internal schema path. Missing-pack errors should include the exact `edi schema install <pack>` command so non-interactive users can recover without guessing.
 - 2026-06-11 (`#121`): CLI recipe/wizard UX should print exact copyable commands before execution. Non-TTY wizard paths must fail fast with a pointer to `edi recipes run` instead of prompting, while `wizard --dry-run` can auto-detect common testdata-like workspaces safely for CI and scheduled agents.
 - 2026-02-09 (`#55`): CSV-to-IR conversion now validates row/header column counts before zipping values. This prevents silent truncation/misalignment when rows contain missing or extra columns and returns a line-specific validation error instead.
 - 2026-02-09: For `edi-adapter-db`, IR write behavior needed explicit mode semantics (`insert`/`update`/`upsert`) plus batch controls in a single API. Adding `WriteMode` + `WriteOptions` avoided duplicated call-site logic and made transactional chunking deterministic for large payloads.

--- a/crates/edi-cli/src/main.rs
+++ b/crates/edi-cli/src/main.rs
@@ -59,6 +59,7 @@ struct CliConfig {
     progress: bool,
     progress_threshold_bytes: u64,
     color: ColorMode,
+    schema_packs: Vec<String>,
     profiles: HashMap<String, ProfileConfig>,
 
     #[serde(skip)]
@@ -71,6 +72,7 @@ impl Default for CliConfig {
             progress: true,
             progress_threshold_bytes: 1024 * 1024,
             color: ColorMode::Auto,
+            schema_packs: Vec::new(),
             profiles: HashMap::new(),
             source_path: None,
         }
@@ -287,6 +289,12 @@ enum Commands {
         command: RecipeCommands,
     },
 
+    /// Discover, install, inspect, and diagnose schema/message packs
+    Schema {
+        #[command(subcommand)]
+        command: SchemaCommands,
+    },
+
     /// Interactively select a common EDI workflow, or print an auto-detected plan with --dry-run
     Wizard {
         /// Print the planned command without prompting or running it
@@ -338,6 +346,10 @@ enum Commands {
         #[arg(short, long)]
         schema: Option<String>,
 
+        /// Auto-detect the schema/message pack from UNH when --schema is omitted
+        #[arg(long, default_value_t = false)]
+        auto_schema: bool,
+
         /// Validation report format
         #[arg(long, value_enum, default_value = "text")]
         report: ValidationReportFormat,
@@ -386,6 +398,24 @@ enum ConfigCommands {
         #[arg(long)]
         profile: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+enum SchemaCommands {
+    /// List built-in and installed schema/message packs
+    List,
+    /// Install a built-in schema/message pack into the current project
+    Install {
+        /// Pack identifier, such as eancom:d96a:orders
+        pack: String,
+    },
+    /// Show schema/message pack metadata and install state
+    Inspect {
+        /// Pack identifier, such as eancom:d96a:orders
+        pack: String,
+    },
+    /// Check configured schema/message packs and files
+    Doctor,
 }
 
 #[derive(Subcommand)]
@@ -490,6 +520,12 @@ fn run() -> anyhow::Result<CliExitCode> {
                     base_runtime,
                 ),
             },
+            Commands::Schema { command } => match command {
+                SchemaCommands::List => schema_list(&config),
+                SchemaCommands::Install { pack } => schema_install(&pack),
+                SchemaCommands::Inspect { pack } => schema_inspect(&config, &pack),
+                SchemaCommands::Doctor => schema_doctor(&config),
+            },
             Commands::Wizard { dry_run } => wizard(dry_run, base_runtime),
             Commands::Transform {
                 input,
@@ -536,6 +572,7 @@ fn run() -> anyhow::Result<CliExitCode> {
             Commands::Validate {
                 input,
                 schema,
+                auto_schema,
                 report,
                 output,
             } => {
@@ -543,12 +580,26 @@ fn run() -> anyhow::Result<CliExitCode> {
                 let runtime = runtime_options(&config, profile);
                 let input =
                     resolve_profile_value(input, profile.and_then(|p| p.input.as_ref()), "input")?;
-                let schema = resolve_profile_value(
-                    schema,
-                    profile.and_then(|p| p.schema.as_ref()),
-                    "schema",
-                )?;
-                validate(&input, &schema, runtime, report, output.as_deref())
+                let schema = if auto_schema {
+                    resolve_auto_schema(&input, schema, profile.and_then(|p| p.schema.as_ref()))?
+                } else {
+                    ResolvedSchema {
+                        path: resolve_profile_value(
+                            schema,
+                            profile.and_then(|p| p.schema.as_ref()),
+                            "schema",
+                        )?,
+                        label: None,
+                    }
+                };
+                validate(
+                    &input,
+                    &schema.path,
+                    runtime,
+                    report,
+                    output.as_deref(),
+                    schema.label.as_deref(),
+                )
             }
             Commands::Parse {
                 input,
@@ -830,6 +881,336 @@ fn check_profile_path(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SchemaPack {
+    id: &'static str,
+    standard: &'static str,
+    version: &'static str,
+    message_type: &'static str,
+    schema_rel_path: &'static str,
+    description: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedSchema {
+    path: String,
+    label: Option<String>,
+}
+
+const BUILT_IN_SCHEMA_PACKS: &[SchemaPack] = &[
+    SchemaPack {
+        id: "eancom:d96a:orders",
+        standard: "EANCOM",
+        version: "D96A",
+        message_type: "ORDERS",
+        schema_rel_path: "testdata/schemas/eancom_orders_d96a.yaml",
+        description: "EANCOM D96A purchase order message",
+    },
+    SchemaPack {
+        id: "eancom:d96a:slsrpt",
+        standard: "EANCOM",
+        version: "D96A",
+        message_type: "SLSRPT",
+        schema_rel_path: "testdata/schemas/eancom_slsrpt_d96a.yaml",
+        description: "EANCOM D96A sales data report message",
+    },
+    SchemaPack {
+        id: "eancom:d96a:ordrsp",
+        standard: "EANCOM",
+        version: "D96A",
+        message_type: "ORDRSP",
+        schema_rel_path: "testdata/schemas/eancom_ordrsp_d96a.yaml",
+        description: "EANCOM D96A purchase order response message",
+    },
+    SchemaPack {
+        id: "eancom:d96a:desadv",
+        standard: "EANCOM",
+        version: "D96A",
+        message_type: "DESADV",
+        schema_rel_path: "testdata/schemas/eancom_desadv_d96a.yaml",
+        description: "EANCOM D96A despatch advice message",
+    },
+    SchemaPack {
+        id: "eancom:d96a:invoic",
+        standard: "EANCOM",
+        version: "D96A",
+        message_type: "INVOIC",
+        schema_rel_path: "testdata/schemas/eancom_invoic_d96a.yaml",
+        description: "EANCOM D96A invoice message",
+    },
+];
+
+fn schema_list(config: &CliConfig) -> anyhow::Result<CliExitCode> {
+    println!("Schema/message packs:");
+    for pack in BUILT_IN_SCHEMA_PACKS {
+        let installed = installed_schema_path(pack).exists()
+            || config.schema_packs.iter().any(|id| id == pack.id);
+        let status = if installed { "installed" } else { "built-in" };
+        println!(
+            "  {:<22} {:<9} {} {} ({status}) - {}",
+            pack.id, pack.standard, pack.version, pack.message_type, pack.description
+        );
+    }
+    Ok(CliExitCode::Success)
+}
+
+fn schema_install(pack_id: &str) -> anyhow::Result<CliExitCode> {
+    let pack = find_built_in_pack(pack_id).ok_or_else(|| unknown_pack_error(pack_id))?;
+    let source = built_in_schema_source_path(pack);
+    if !source.exists() {
+        bail!(
+            "Built-in schema source '{}' for pack '{}' was not found",
+            source.display(),
+            pack.id
+        );
+    }
+
+    let destination = installed_schema_path(pack);
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create schema directory '{}'", parent.display()))?;
+    }
+    std::fs::copy(&source, &destination).with_context(|| {
+        format!(
+            "Failed to install schema pack '{}' from '{}' to '{}'",
+            pack.id,
+            source.display(),
+            destination.display()
+        )
+    })?;
+    record_installed_schema_pack(pack.id)?;
+    println!(
+        "Installed {} to {} and recorded it in rsedi.yaml.",
+        pack.id,
+        destination.display()
+    );
+    Ok(CliExitCode::Success)
+}
+
+fn schema_inspect(config: &CliConfig, pack_id: &str) -> anyhow::Result<CliExitCode> {
+    let pack = find_built_in_pack(pack_id).ok_or_else(|| unknown_pack_error(pack_id))?;
+    println!("id: {}", pack.id);
+    println!("standard: {}", pack.standard);
+    println!("version: {}", pack.version);
+    println!("message_type: {}", pack.message_type);
+    println!("description: {}", pack.description);
+    println!(
+        "built_in_schema: {}",
+        built_in_schema_source_path(pack).display()
+    );
+    let installed_path = installed_schema_path(pack);
+    println!("installed_schema: {}", installed_path.display());
+    println!(
+        "installed: {}",
+        installed_path.exists() || config.schema_packs.iter().any(|id| id == pack.id)
+    );
+    Ok(CliExitCode::Success)
+}
+
+fn schema_doctor(config: &CliConfig) -> anyhow::Result<CliExitCode> {
+    let mut errors = 0usize;
+    for pack_id in &config.schema_packs {
+        match find_built_in_pack(pack_id) {
+            Some(pack) => {
+                let installed_path = installed_schema_path(pack);
+                let built_in_path = built_in_schema_source_path(pack);
+                if installed_path.exists() || built_in_path.exists() {
+                    println!("OK: {}", pack.id);
+                } else {
+                    errors += 1;
+                    println!("Missing: {} (run: edi schema install {})", pack.id, pack.id);
+                }
+            }
+            None => {
+                errors += 1;
+                println!("Unknown configured schema pack: {pack_id}");
+            }
+        }
+    }
+    if config.schema_packs.is_empty() {
+        println!("No installed schema packs recorded in config.");
+    }
+    Ok(if errors == 0 {
+        CliExitCode::Success
+    } else {
+        CliExitCode::Errors
+    })
+}
+
+fn resolve_auto_schema(
+    input_path: &str,
+    explicit_schema: Option<String>,
+    profile_schema: Option<&PathBuf>,
+) -> anyhow::Result<ResolvedSchema> {
+    if let Some(path) = explicit_schema {
+        return Ok(ResolvedSchema { path, label: None });
+    }
+    if let Some(path) = profile_schema {
+        return Ok(ResolvedSchema {
+            path: path.to_string_lossy().into_owned(),
+            label: None,
+        });
+    }
+
+    let message = detect_message_type(input_path)?;
+    let Some(pack) = find_pack_for_message(&message) else {
+        let candidate = message.pack_id();
+        bail!(
+            "No schema pack installed or built in for {} {}. Install it with: edi schema install {}",
+            message.message_type,
+            message.version,
+            candidate
+        );
+    };
+
+    let path = resolve_pack_schema_path(pack)?;
+    println!("Auto-selected schema pack {} ({})", pack.id, path.display());
+    Ok(ResolvedSchema {
+        path: path.to_string_lossy().into_owned(),
+        label: Some(pack.id.to_string()),
+    })
+}
+
+#[derive(Debug, Clone)]
+struct DetectedMessageType {
+    message_type: String,
+    version: String,
+}
+
+impl DetectedMessageType {
+    fn pack_id(&self) -> String {
+        format!(
+            "eancom:{}:{}",
+            self.version.to_ascii_lowercase(),
+            self.message_type.to_ascii_lowercase()
+        )
+    }
+}
+
+fn detect_message_type(input_path: &str) -> anyhow::Result<DetectedMessageType> {
+    let input_bytes = std::fs::read(input_path)
+        .with_context(|| format!("Failed to read input file '{}'", input_path))?;
+    let parser = EdifactParser::new();
+    let parsed = parser
+        .parse_with_warnings(&input_bytes, input_path)
+        .with_context(|| format!("Failed to parse EDIFACT input '{}'", input_path))?;
+    let document = parsed
+        .documents
+        .first()
+        .ok_or_else(|| anyhow!("No EDIFACT messages were found in '{}'", input_path))?;
+    extract_message_type(document).ok_or_else(|| {
+        anyhow!(
+            "Could not auto-detect schema because the first message has no UNH message type/version"
+        )
+    })
+}
+
+fn extract_message_type(document: &Document) -> Option<DetectedMessageType> {
+    let unh = document.root.find_child("UNH")?;
+    let message_identifier = unh.children.get(1)?;
+    let message_type = node_value(message_identifier.children.first()?)?;
+    let release = node_value(message_identifier.children.get(1)?)?;
+    let version = node_value(message_identifier.children.get(2)?)?;
+    Some(DetectedMessageType {
+        message_type: message_type.to_ascii_uppercase(),
+        version: format!("{release}{version}").to_ascii_uppercase(),
+    })
+}
+
+fn node_value(node: &edi_ir::Node) -> Option<String> {
+    node.value.as_ref().and_then(Value::as_string)
+}
+
+fn find_pack_for_message(message: &DetectedMessageType) -> Option<&'static SchemaPack> {
+    BUILT_IN_SCHEMA_PACKS.iter().find(|pack| {
+        pack.message_type
+            .eq_ignore_ascii_case(&message.message_type)
+            && pack.version.eq_ignore_ascii_case(&message.version)
+    })
+}
+
+fn find_built_in_pack(pack_id: &str) -> Option<&'static SchemaPack> {
+    BUILT_IN_SCHEMA_PACKS
+        .iter()
+        .find(|pack| pack.id.eq_ignore_ascii_case(pack_id))
+}
+
+fn unknown_pack_error(pack_id: &str) -> anyhow::Error {
+    anyhow!(
+        "Unknown schema pack '{}'. Run 'edi schema list' to see available packs.",
+        pack_id
+    )
+}
+
+fn resolve_pack_schema_path(pack: &SchemaPack) -> anyhow::Result<PathBuf> {
+    let installed = installed_schema_path(pack);
+    if installed.exists() {
+        return Ok(installed);
+    }
+    let built_in = built_in_schema_source_path(pack);
+    if built_in.exists() {
+        return Ok(built_in);
+    }
+    bail!(
+        "No schema pack installed or built in for {} {}. Install it with: edi schema install {}",
+        pack.message_type,
+        pack.version,
+        pack.id
+    );
+}
+
+fn installed_schema_path(pack: &SchemaPack) -> PathBuf {
+    let mut parts = pack.id.split(':');
+    let standard = parts.next().unwrap_or("schema");
+    let version = parts.next().unwrap_or("version");
+    let message = parts.next().unwrap_or("message");
+    Path::new("schemas")
+        .join(standard)
+        .join(version)
+        .join(format!("{message}.yaml"))
+}
+
+fn built_in_schema_source_path(pack: &SchemaPack) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(pack.schema_rel_path)
+}
+
+fn record_installed_schema_pack(pack_id: &str) -> anyhow::Result<()> {
+    let config_path = Path::new("rsedi.yaml");
+    if !config_path.exists() {
+        let config = format!("schema_packs:\n  - {pack_id}\nprofiles: {{}}\n");
+        std::fs::write(config_path, config)
+            .with_context(|| format!("Failed to write '{}'", config_path.display()))?;
+        return Ok(());
+    }
+
+    let mut config = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read '{}'", config_path.display()))?;
+    if config.contains(&format!("- {pack_id}")) || config.contains(&format!("\"{pack_id}\"")) {
+        return Ok(());
+    }
+    if config.contains("schema_packs:") {
+        let mut lines = Vec::new();
+        let mut inserted = false;
+        for line in config.lines() {
+            lines.push(line.to_string());
+            if !inserted && line.trim() == "schema_packs:" {
+                lines.push(format!("  - {pack_id}"));
+                inserted = true;
+            }
+        }
+        config = lines.join("\n");
+        config.push('\n');
+    } else {
+        config = format!("schema_packs:\n  - {pack_id}\n{config}");
+    }
+    std::fs::write(config_path, config)
+        .with_context(|| format!("Failed to update '{}'", config_path.display()))?;
+    Ok(())
+}
+
 fn mapping_lint(mapping_path: &str, schema_path: Option<&str>) -> anyhow::Result<CliExitCode> {
     let mapping = MappingDsl::parse_file(Path::new(mapping_path))
         .with_context(|| format!("Failed to parse mapping '{}'", mapping_path))?;
@@ -898,6 +1279,7 @@ fn recipes_run(
             runtime,
             ValidationReportFormat::Text,
             output,
+            None,
         ),
         RecipeName::OrdersToJson | RecipeName::OrdersToCsv => transform(
             required_recipe_arg(name, "input", input)?,
@@ -1044,6 +1426,7 @@ fn batch_validate_directory(
             schema_path,
             runtime,
             ValidationReportFormat::Text,
+            None,
             None,
         )?;
         worst = max_exit_code(worst, code);
@@ -1826,6 +2209,7 @@ fn validate(
     runtime: RuntimeOptions,
     report_format: ValidationReportFormat,
     report_output_path: Option<&str>,
+    schema_label: Option<&str>,
 ) -> anyhow::Result<CliExitCode> {
     tracing::info!(input = %input_path, schema = %schema_path, "Starting validate command");
 
@@ -1916,7 +2300,7 @@ fn validate(
 
     let report = ValidationCliReport {
         source: input_path.to_string(),
-        schema: schema_path.to_string(),
+        schema: schema_label.unwrap_or(schema_path).to_string(),
         summary: ValidationReportSummary {
             messages: parsed.documents.len(),
             errors: error_count,

--- a/crates/edi-cli/src/main.rs
+++ b/crates/edi-cli/src/main.rs
@@ -1179,34 +1179,40 @@ fn built_in_schema_source_path(pack: &SchemaPack) -> PathBuf {
 
 fn record_installed_schema_pack(pack_id: &str) -> anyhow::Result<()> {
     let config_path = Path::new("rsedi.yaml");
-    if !config_path.exists() {
-        let config = format!("schema_packs:\n  - {pack_id}\nprofiles: {{}}\n");
-        std::fs::write(config_path, config)
-            .with_context(|| format!("Failed to write '{}'", config_path.display()))?;
-        return Ok(());
+    let mut config = if config_path.exists() {
+        let config_text = std::fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read '{}'", config_path.display()))?;
+        serde_yaml::from_str::<serde_yaml::Value>(&config_text)
+            .with_context(|| format!("Failed to parse '{}'", config_path.display()))?
+    } else {
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+    };
+
+    let mapping = config.as_mapping_mut().ok_or_else(|| {
+        anyhow!(
+            "Failed to update '{}': root YAML value must be a mapping",
+            config_path.display()
+        )
+    })?;
+    let key = serde_yaml::Value::String("schema_packs".to_string());
+    let packs = mapping
+        .entry(key)
+        .or_insert_with(|| serde_yaml::Value::Sequence(Vec::new()));
+    let sequence = packs.as_sequence_mut().ok_or_else(|| {
+        anyhow!(
+            "Failed to update '{}': schema_packs must be a YAML list",
+            config_path.display()
+        )
+    })?;
+
+    let already_recorded = sequence.iter().any(|value| value.as_str() == Some(pack_id));
+    if !already_recorded {
+        sequence.push(serde_yaml::Value::String(pack_id.to_string()));
     }
 
-    let mut config = std::fs::read_to_string(config_path)
-        .with_context(|| format!("Failed to read '{}'", config_path.display()))?;
-    if config.contains(&format!("- {pack_id}")) || config.contains(&format!("\"{pack_id}\"")) {
-        return Ok(());
-    }
-    if config.contains("schema_packs:") {
-        let mut lines = Vec::new();
-        let mut inserted = false;
-        for line in config.lines() {
-            lines.push(line.to_string());
-            if !inserted && line.trim() == "schema_packs:" {
-                lines.push(format!("  - {pack_id}"));
-                inserted = true;
-            }
-        }
-        config = lines.join("\n");
-        config.push('\n');
-    } else {
-        config = format!("schema_packs:\n  - {pack_id}\n{config}");
-    }
-    std::fs::write(config_path, config)
+    let rendered = serde_yaml::to_string(&config)
+        .with_context(|| format!("Failed to render '{}'", config_path.display()))?;
+    std::fs::write(config_path, rendered)
         .with_context(|| format!("Failed to update '{}'", config_path.display()))?;
     Ok(())
 }

--- a/crates/edi-cli/tests/schema_command_test.rs
+++ b/crates/edi-cli/tests/schema_command_test.rs
@@ -37,6 +37,8 @@ fn testdata_path(path: &str) -> PathBuf {
     repo_root().join(path)
 }
 
+const UNSUPPORTED_INVRPT_PAYLOAD: &str = "UNH+1+INVRPT:D:96A:UN'BGM+35+REPORT1+9'UNT+3+1'";
+
 fn temp_workspace(name: &str) -> PathBuf {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -143,8 +145,7 @@ fn validate_auto_schema_detects_orders_pack_without_schema_path() {
 fn validate_auto_schema_reports_install_command_for_missing_pack() {
     let workspace = temp_workspace("missing-pack");
     let input = workspace.join("unsupported.edi");
-    fs::write(&input, "UNH+1+INVRPT:D:96A:UN'BGM+35+REPORT1+9'UNT+3+1'")
-        .expect("write unsupported EDI");
+    fs::write(&input, UNSUPPORTED_INVRPT_PAYLOAD).expect("write unsupported EDI");
 
     let output = Command::new(cargo_bin())
         .current_dir(&workspace)

--- a/crates/edi-cli/tests/schema_command_test.rs
+++ b/crates/edi-cli/tests/schema_command_test.rs
@@ -1,0 +1,169 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn cargo_bin() -> PathBuf {
+    if let Ok(path) = env::var("CARGO_BIN_EXE_edi") {
+        return PathBuf::from(path);
+    }
+
+    let target_dir = env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| repo_root().join("target"));
+    let executable_name = format!("edi{}", std::env::consts::EXE_SUFFIX);
+
+    for profile in ["debug", "release"] {
+        let candidate = target_dir.join(profile).join(&executable_name);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    panic!(
+        "cargo_bin() could not find {executable_name} under {} debug or release directories",
+        target_dir.display()
+    );
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+}
+
+fn testdata_path(path: &str) -> PathBuf {
+    repo_root().join(path)
+}
+
+fn temp_workspace(name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_nanos();
+    let path = env::temp_dir().join(format!("rsedi-{name}-{unique}"));
+    fs::create_dir_all(&path).expect("create temp workspace");
+    path
+}
+
+#[test]
+fn schema_list_and_inspect_show_built_in_message_packs() {
+    let list = Command::new(cargo_bin())
+        .args(["schema", "list"])
+        .output()
+        .expect("run edi schema list");
+
+    assert!(
+        list.status.success(),
+        "expected list to succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&list.stdout),
+        String::from_utf8_lossy(&list.stderr)
+    );
+    let stdout = String::from_utf8(list.stdout).expect("stdout is UTF-8");
+    for pack in [
+        "eancom:d96a:orders",
+        "eancom:d96a:slsrpt",
+        "eancom:d96a:ordrsp",
+    ] {
+        assert!(stdout.contains(pack), "missing pack {pack} in {stdout}");
+    }
+
+    let inspect = Command::new(cargo_bin())
+        .args(["schema", "inspect", "eancom:d96a:orders"])
+        .output()
+        .expect("run edi schema inspect");
+    assert!(
+        inspect.status.success(),
+        "expected inspect to succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&inspect.stdout),
+        String::from_utf8_lossy(&inspect.stderr)
+    );
+    let stdout = String::from_utf8(inspect.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("message_type: ORDERS"), "stdout: {stdout}");
+    assert!(stdout.contains("version: D96A"), "stdout: {stdout}");
+}
+
+#[test]
+fn schema_install_copies_pack_and_records_project_config() {
+    let workspace = temp_workspace("schema-install");
+
+    let install = Command::new(cargo_bin())
+        .current_dir(&workspace)
+        .args(["schema", "install", "eancom:d96a:orders"])
+        .output()
+        .expect("run edi schema install");
+
+    assert!(
+        install.status.success(),
+        "expected install to succeed; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&install.stdout),
+        String::from_utf8_lossy(&install.stderr)
+    );
+
+    let installed_schema = workspace.join("schemas/eancom/d96a/orders.yaml");
+    assert!(installed_schema.exists(), "schema was not installed");
+    let config = fs::read_to_string(workspace.join("rsedi.yaml")).expect("read generated config");
+    assert!(
+        config.contains("eancom:d96a:orders"),
+        "installed pack was not recorded in config: {config}"
+    );
+}
+
+#[test]
+fn validate_auto_schema_detects_orders_pack_without_schema_path() {
+    let input = testdata_path("testdata/edi/valid_orders_d96a_minimal.edi");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(repo_root())
+        .args([
+            "validate",
+            input.to_string_lossy().as_ref(),
+            "--auto-schema",
+        ])
+        .output()
+        .expect("run edi validate --auto-schema");
+
+    assert!(
+        output.status.success(),
+        "expected auto-schema validation to pass; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(
+        stdout.contains("eancom:d96a:orders"),
+        "auto-schema selection did not name the selected pack: {stdout}"
+    );
+    assert!(stdout.contains("Validation passed"), "stdout: {stdout}");
+}
+
+#[test]
+fn validate_auto_schema_reports_install_command_for_missing_pack() {
+    let workspace = temp_workspace("missing-pack");
+    let input = workspace.join("unsupported.edi");
+    fs::write(&input, "UNH+1+INVRPT:D:96A:UN'BGM+35+REPORT1+9'UNT+3+1'")
+        .expect("write unsupported EDI");
+
+    let output = Command::new(cargo_bin())
+        .current_dir(&workspace)
+        .args([
+            "validate",
+            input.to_string_lossy().as_ref(),
+            "--auto-schema",
+        ])
+        .output()
+        .expect("run edi validate --auto-schema");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr.contains("No schema pack installed or built in"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("edi schema install eancom:d96a:invrpt"),
+        "stderr should include install command: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #124.

## Summary
- Add `edi schema list|install|inspect|doctor` for built-in EANCOM D96A message packs.
- Add `edi validate --auto-schema` to detect the message type/version from UNH and select the matching pack.
- Record installed packs in `rsedi.yaml` and include exact install commands for unsupported/missing packs.
- Add CLI integration tests covering schema discovery, install/config persistence, auto-schema validation, and missing-pack diagnostics.

## Test plan
- `cargo test -p edi-cli --test schema_command_test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added `schema` subcommand to manage, list, install, and inspect message packs
* Validation now supports `--auto-schema` flag to auto-detect schema from message content
* Installed schema packs persist across CLI sessions
* Improved error messaging for missing schema packs with installation instructions

**Documentation**
* Updated learnings with CLI auto-schema behavior details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->