### PR TITLE
refactor(cli): extract batch report boundary

### DIFF
--- a/crates/edi-cli/src/batch.rs
+++ b/crates/edi-cli/src/batch.rs
@@ -1,0 +1,115 @@
+use serde::Serialize;
+
+use crate::BatchOutputFormat;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BatchSummary {
+    pub(crate) command: &'static str,
+    pub(crate) processed: usize,
+    pub(crate) succeeded: usize,
+    pub(crate) warned: usize,
+    pub(crate) failed: usize,
+    pub(crate) quarantined: usize,
+    pub(crate) outputs: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BatchFileOutcome {
+    pub(crate) source: String,
+    pub(crate) status: &'static str,
+    pub(crate) messages: usize,
+    pub(crate) errors: usize,
+    pub(crate) warnings: usize,
+    pub(crate) output: Option<String>,
+    pub(crate) quarantine_id: Option<String>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BatchReport {
+    pub(crate) summary: BatchSummary,
+    pub(crate) files: Vec<BatchFileOutcome>,
+}
+
+pub(crate) fn build_batch_report(
+    command: &'static str,
+    files: Vec<BatchFileOutcome>,
+    quarantined: usize,
+) -> BatchReport {
+    let summary = BatchSummary {
+        command,
+        processed: files.len(),
+        succeeded: files.iter().filter(|file| file.status == "success").count(),
+        warned: files.iter().filter(|file| file.status == "warning").count(),
+        failed: files.iter().filter(|file| file.status == "failed").count(),
+        quarantined,
+        outputs: files.iter().filter(|file| file.output.is_some()).count(),
+    };
+    BatchReport { summary, files }
+}
+
+pub(crate) fn write_batch_report(
+    report: &BatchReport,
+    format: BatchOutputFormat,
+) -> anyhow::Result<()> {
+    match format {
+        BatchOutputFormat::Json => {
+            println!("{}", serde_json::to_string(report)?);
+        }
+        BatchOutputFormat::Text => {
+            println!(
+                "Batch {} summary: processed={}, succeeded={}, warnings={}, failed={}, quarantined={}, outputs={}",
+                report.summary.command,
+                report.summary.processed,
+                report.summary.succeeded,
+                report.summary.warned,
+                report.summary.failed,
+                report.summary.quarantined,
+                report.summary.outputs
+            );
+            for file in &report.files {
+                println!("{}: {}", file.status, file.source);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome(status: &'static str, output: Option<&str>) -> BatchFileOutcome {
+        BatchFileOutcome {
+            source: format!("{status}.edi"),
+            status,
+            messages: 1,
+            errors: usize::from(status == "failed"),
+            warnings: usize::from(status == "warning"),
+            output: output.map(str::to_owned),
+            quarantine_id: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn batch_report_summary_counts_statuses_and_outputs() {
+        let report = build_batch_report(
+            "transform",
+            vec![
+                outcome("success", Some("success.json")),
+                outcome("warning", Some("warning.json")),
+                outcome("failed", None),
+            ],
+            1,
+        );
+
+        assert_eq!(report.summary.command, "transform");
+        assert_eq!(report.summary.processed, 3);
+        assert_eq!(report.summary.succeeded, 1);
+        assert_eq!(report.summary.warned, 1);
+        assert_eq!(report.summary.failed, 1);
+        assert_eq!(report.summary.quarantined, 1);
+        assert_eq!(report.summary.outputs, 2);
+    }
+}

--- a/crates/edi-cli/src/batch.rs
+++ b/crates/edi-cli/src/batch.rs
@@ -2,6 +2,24 @@ use serde::Serialize;
 
 use crate::BatchOutputFormat;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum FileStatus {
+    Success,
+    Warning,
+    Failed,
+}
+
+impl FileStatus {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Warning => "warning",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct BatchSummary {
     pub(crate) command: &'static str,
@@ -16,7 +34,7 @@ pub(crate) struct BatchSummary {
 #[derive(Debug, Serialize)]
 pub(crate) struct BatchFileOutcome {
     pub(crate) source: String,
-    pub(crate) status: &'static str,
+    pub(crate) status: FileStatus,
     pub(crate) messages: usize,
     pub(crate) errors: usize,
     pub(crate) warnings: usize,
@@ -39,9 +57,18 @@ pub(crate) fn build_batch_report(
     let summary = BatchSummary {
         command,
         processed: files.len(),
-        succeeded: files.iter().filter(|file| file.status == "success").count(),
-        warned: files.iter().filter(|file| file.status == "warning").count(),
-        failed: files.iter().filter(|file| file.status == "failed").count(),
+        succeeded: files
+            .iter()
+            .filter(|file| file.status == FileStatus::Success)
+            .count(),
+        warned: files
+            .iter()
+            .filter(|file| file.status == FileStatus::Warning)
+            .count(),
+        failed: files
+            .iter()
+            .filter(|file| file.status == FileStatus::Failed)
+            .count(),
         quarantined,
         outputs: files.iter().filter(|file| file.output.is_some()).count(),
     };
@@ -68,7 +95,7 @@ pub(crate) fn write_batch_report(
                 report.summary.outputs
             );
             for file in &report.files {
-                println!("{}: {}", file.status, file.source);
+                println!("{}: {}", file.status.as_str(), file.source);
             }
         }
     }
@@ -79,13 +106,13 @@ pub(crate) fn write_batch_report(
 mod tests {
     use super::*;
 
-    fn outcome(status: &'static str, output: Option<&str>) -> BatchFileOutcome {
+    fn outcome(status: FileStatus, output: Option<&str>) -> BatchFileOutcome {
         BatchFileOutcome {
-            source: format!("{status}.edi"),
+            source: format!("{}.edi", status.as_str()),
             status,
             messages: 1,
-            errors: usize::from(status == "failed"),
-            warnings: usize::from(status == "warning"),
+            errors: usize::from(status == FileStatus::Failed),
+            warnings: usize::from(status == FileStatus::Warning),
             output: output.map(str::to_owned),
             quarantine_id: None,
             error: None,
@@ -97,9 +124,9 @@ mod tests {
         let report = build_batch_report(
             "transform",
             vec![
-                outcome("success", Some("success.json")),
-                outcome("warning", Some("warning.json")),
-                outcome("failed", None),
+                outcome(FileStatus::Success, Some("success.json")),
+                outcome(FileStatus::Warning, Some("warning.json")),
+                outcome(FileStatus::Failed, None),
             ],
             1,
         );

--- a/crates/edi-cli/src/main.rs
+++ b/crates/edi-cli/src/main.rs
@@ -34,7 +34,7 @@ mod config;
 mod quarantine;
 mod schema_packs;
 
-use batch::{BatchFileOutcome, build_batch_report, write_batch_report};
+use batch::{BatchFileOutcome, FileStatus, build_batch_report, write_batch_report};
 use config::{CliConfig, ColorMode, ProfileConfig, load_cli_config};
 use quarantine::{
     quarantine_export, quarantine_list, quarantine_payload_path, quarantine_show,
@@ -1200,9 +1200,9 @@ fn batch_validate(
         match result {
             Ok(counts) if counts.errors == 0 => {
                 let status = if counts.warnings > 0 {
-                    "warning"
+                    FileStatus::Warning
                 } else {
-                    "success"
+                    FileStatus::Success
                 };
                 if counts.warnings > 0 {
                     worst = max_exit_code(worst, CliExitCode::Warnings);
@@ -1227,7 +1227,7 @@ fn batch_validate(
                 quarantined += usize::from(quarantine_id.is_some());
                 outcomes.push(BatchFileOutcome {
                     source,
-                    status: "failed",
+                    status: FileStatus::Failed,
                     messages: counts.messages,
                     errors: counts.errors,
                     warnings: counts.warnings,
@@ -1248,7 +1248,7 @@ fn batch_validate(
                 quarantined += usize::from(quarantine_id.is_some());
                 outcomes.push(BatchFileOutcome {
                     source,
-                    status: "failed",
+                    status: FileStatus::Failed,
                     messages: 0,
                     errors: 1,
                     warnings: 0,
@@ -1320,9 +1320,9 @@ fn batch_transform(
                 outcomes.push(BatchFileOutcome {
                     source,
                     status: if code == CliExitCode::Warnings {
-                        "warning"
+                        FileStatus::Warning
                     } else {
-                        "success"
+                        FileStatus::Success
                     },
                     messages: 0,
                     errors: 0,
@@ -1341,7 +1341,7 @@ fn batch_transform(
                 quarantined += usize::from(quarantine_id.is_some());
                 outcomes.push(BatchFileOutcome {
                     source,
-                    status: "failed",
+                    status: FileStatus::Failed,
                     messages: 0,
                     errors: 1,
                     warnings: 0,
@@ -1362,7 +1362,7 @@ fn batch_transform(
                 quarantined += usize::from(quarantine_id.is_some());
                 outcomes.push(BatchFileOutcome {
                     source,
-                    status: "failed",
+                    status: FileStatus::Failed,
                     messages: 0,
                     errors: 1,
                     warnings: 0,

--- a/crates/edi-cli/src/main.rs
+++ b/crates/edi-cli/src/main.rs
@@ -29,10 +29,12 @@ use edi_schema::{Schema, SchemaLoader};
 use edi_validation::{Severity, ValidationEngine, ValidationIssue};
 use serde::Serialize;
 
+mod batch;
 mod config;
 mod quarantine;
 mod schema_packs;
 
+use batch::{BatchFileOutcome, build_batch_report, write_batch_report};
 use config::{CliConfig, ColorMode, ProfileConfig, load_cli_config};
 use quarantine::{
     quarantine_export, quarantine_list, quarantine_payload_path, quarantine_show,
@@ -1170,35 +1172,6 @@ fn max_exit_code(left: CliExitCode, right: CliExitCode) -> CliExitCode {
     }
 }
 
-#[derive(Debug, Serialize)]
-struct BatchSummary {
-    command: &'static str,
-    processed: usize,
-    succeeded: usize,
-    warned: usize,
-    failed: usize,
-    quarantined: usize,
-    outputs: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct BatchFileOutcome {
-    source: String,
-    status: &'static str,
-    messages: usize,
-    errors: usize,
-    warnings: usize,
-    output: Option<String>,
-    quarantine_id: Option<String>,
-    error: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-struct BatchReport {
-    summary: BatchSummary,
-    files: Vec<BatchFileOutcome>,
-}
-
 fn batch_validate(
     input: &str,
     schema_path: &str,
@@ -1449,47 +1422,6 @@ fn validate_file_counts(path: &Path, schema: &Schema) -> anyhow::Result<Validati
         }
     }
     Ok(counts)
-}
-
-fn build_batch_report(
-    command: &'static str,
-    files: Vec<BatchFileOutcome>,
-    quarantined: usize,
-) -> BatchReport {
-    let summary = BatchSummary {
-        command,
-        processed: files.len(),
-        succeeded: files.iter().filter(|file| file.status == "success").count(),
-        warned: files.iter().filter(|file| file.status == "warning").count(),
-        failed: files.iter().filter(|file| file.status == "failed").count(),
-        quarantined,
-        outputs: files.iter().filter(|file| file.output.is_some()).count(),
-    };
-    BatchReport { summary, files }
-}
-
-fn write_batch_report(report: &BatchReport, format: BatchOutputFormat) -> anyhow::Result<()> {
-    match format {
-        BatchOutputFormat::Json => {
-            println!("{}", serde_json::to_string(report)?);
-        }
-        BatchOutputFormat::Text => {
-            println!(
-                "Batch {} summary: processed={}, succeeded={}, warnings={}, failed={}, quarantined={}, outputs={}",
-                report.summary.command,
-                report.summary.processed,
-                report.summary.succeeded,
-                report.summary.warned,
-                report.summary.failed,
-                report.summary.quarantined,
-                report.summary.outputs
-            );
-            for file in &report.files {
-                println!("{}: {}", file.status, file.source);
-            }
-        }
-    }
-    Ok(())
 }
 
 fn collect_edi_input_paths(input: &str) -> anyhow::Result<Vec<PathBuf>> {


### PR DESCRIPTION
## Summary
- Extract batch report data model and renderer from `main.rs` into `crates/edi-cli/src/batch.rs`.
- Add focused unit coverage for batch summary aggregation.
- Keep batch validate/transform orchestration behavior unchanged.

Refs #138

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p edi-cli --all-targets --all-features -- -D warnings`
- `cargo test -p edi-cli --all-targets --all-features`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized batch reporting functionality into a dedicated internal module for improved code maintainability and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->